### PR TITLE
Adding time-based event loop, updating camera frames every 0.4 seconds

### DIFF
--- a/src/fxml/camera.fxml
+++ b/src/fxml/camera.fxml
@@ -1,30 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.AnchorPane?>
 
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="sample.CameraController">
+<AnchorPane fx:id="root" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="sample.CameraController">
    <children>
       <ImageView fx:id="camera1" fitHeight="200.0" fitWidth="300.0" pickOnBounds="true" preserveRatio="true">
-         <image>
-            <Image url="@../images/WesternLogo.png" />
-         </image>
       </ImageView>
       <ImageView fx:id="camera2" fitHeight="200.0" fitWidth="300.0" layoutX="300.0" pickOnBounds="true" preserveRatio="true">
-         <image>
-            <Image url="@../images/WesternLogo.png" />
-         </image>
       </ImageView>
       <ImageView fx:id="camera4" fitHeight="200.0" fitWidth="300.0" layoutX="300.0" layoutY="200.0" pickOnBounds="true" preserveRatio="true">
-         <image>
-            <Image url="@../images/WesternLogo.png" />
-         </image>
       </ImageView>
       <ImageView fx:id="camera3" fitHeight="200.0" fitWidth="300.0" layoutY="200.0" pickOnBounds="true" preserveRatio="true">
-         <image>
-            <Image url="@../images/WesternLogo.png" />
-         </image>
       </ImageView>
    </children>
 </AnchorPane>

--- a/src/sample/CameraController.java
+++ b/src/sample/CameraController.java
@@ -5,56 +5,82 @@ import javafx.fxml.Initializable;
 import java.net.URL;
 import java.util.ResourceBundle;
 
-import javafx.scene.control.*;
 import javafx.fxml.FXMLLoader;
-import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 import javafx.scene.image.*;
 import javafx.scene.image.ImageView;
-import javafx.scene.image.ImageViewBuilder;
 import java.lang.*;
+import javafx.scene.layout.AnchorPane;
 
 public class CameraController implements Initializable {
-    private Stage stage;
+    private static Stage stage;
 
     @FXML
-    private static ImageView camera1, camera2, camera3, camera4;
-
+    private ImageView camera1;
+    @FXML
+    private ImageView camera2;
+    @FXML
+    private ImageView camera3;
+    @FXML
+    private ImageView camera4;
+    @FXML
+    private AnchorPane root;
     // a little more explicit than an array
     private String camera1Source, camera2Source, camera3Source, camera4Source;
 
+
     public CameraController() {
-        camera1Source = Controller.getJestonIP()+"/camera1";
-        camera2Source = Controller.getJestonIP()+"/camera2";
-        camera3Source = Controller.getJestonIP()+"/camera3";
-        camera4Source = Controller.getJestonIP()+"/camera4";
+        updateAddresses();
     }
+
     public void openWindow() {
-        Parent root;
         try {
             FXMLLoader loader = new FXMLLoader(getClass().getClassLoader().getResource("file:src/fxml/camera.fxml"));
             loader.setLocation(new URL("file:src/fxml/camera.fxml"));
-            root = (Parent)loader.load();
+            root = (AnchorPane) loader.load();
             stage = new Stage();
             stage.setTitle("Rover Camera Feed");
             stage.setScene(new Scene(root, 600, 400));
             stage.setResizable(false);
             stage.show();
 
+            update();
         } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
-    // TODO: fix this
+    /**
+     * TODO: make this work in the long run
+     * For some reason private ImageView's all are null after initialize(), but root AnchorPane isn't
+     * This works, as long as Nodes 0-3 of the root AnchorPane are ImageViews
+      */
     public void update() {
-        // deprecated but works
-        final Image image1 = new Image("https://images.ctfassets.net/zw48pl1isxmc/4QYN7VubAAgEAGs0EuWguw/165749ef2fa01c1c004b6a167fd27835/ab-testing.png");
-        camera1 = new ImageView(image1);
-       // camera1.setImage(camera1Image);
+        try {
+            ((ImageView)root.getChildren().get(0)).setImage(new Image(camera1Source));
+            ((ImageView)root.getChildren().get(1)).setImage(new Image(camera2Source));
+            ((ImageView)root.getChildren().get(2)).setImage(new Image(camera3Source));
+            ((ImageView)root.getChildren().get(3)).setImage(new Image(camera4Source));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    public void updateAddresses() {
+        /*
+        UNCOMMENT ONCE JETSON STUFF IS IMPLEMENTED
+        camera1Source = Controller.getJestonIP()+"/camera1";
+        camera2Source = Controller.getJestonIP()+"/camera2";
+        camera3Source = Controller.getJestonIP()+"/camera3";
+        camera4Source = Controller.getJestonIP()+"/camera4";
+        */
+        // TODO: use commented out stuff in future (this is for testing)
+        camera1Source = camera2Source = camera3Source = camera4Source = "https://static.thenounproject.com/png/302033-200.png";
     }
 
     @Override
-    public void initialize(URL url, ResourceBundle rb) { /* do nothing */ }
+    public void initialize(URL url, ResourceBundle rb) { /* Do nothing */ }
+
 }

--- a/src/sample/Controller.java
+++ b/src/sample/Controller.java
@@ -1,5 +1,6 @@
 package sample;
 
+import javafx.animation.Animation;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import java.net.URL;
@@ -9,7 +10,13 @@ import javafx.scene.control.*;
 
 import java.util.*;
 import java.lang.*;
-
+import javafx.animation.Timeline;
+import javafx.animation.KeyFrame;
+import javafx.util.Duration;
+//import java.awt.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.event.Event;
+import javafx.event.ActionEvent;
 
 public class Controller implements Initializable {
     /**
@@ -37,6 +44,26 @@ public class Controller implements Initializable {
     private Label motor6;
 
     private CommunicationsController comms;
+    private static CameraController cameras;
+
+    /**
+     * Any tasks that affect GUI elements need to run in a timeline handle()
+     * Background tasks not affecting GUI stuff can run in Worker threads
+     *
+     * https://stackoverflow.com/questions/9966136/javafx-periodic-background-task
+     */
+    Timeline secondLoop = new Timeline(new KeyFrame(Duration.seconds(0.4), new EventHandler<ActionEvent>() {
+
+        @Override
+        public void handle(ActionEvent event) {
+            try {
+                cameras.update();
+                System.out.println("UPDATE");
+            } catch (Exception e) {
+                /* Do nothing */
+            }
+        }
+    }));
 
     @Override
     public void initialize(URL url, ResourceBundle rb) {
@@ -44,9 +71,11 @@ public class Controller implements Initializable {
         comms = new CommunicationsController();
 
         /* Initialize camera feeds */
-        CameraController cameras = new CameraController();
+        cameras = new CameraController();
         cameras.openWindow();
-        cameras.update();
+
+        secondLoop.setCycleCount(Animation.INDEFINITE);
+        secondLoop.play();
     }
 
     public void roverHTTPGet()
@@ -74,10 +103,23 @@ public class Controller implements Initializable {
     }
 
     // setters for IP's for device
-    public static void setDriveIP(String ip) { driveIP = ip; }
-    public static void setScience1IP(String ip) { science1IP = ip; }
-    public static void setArmIP(String ip) { armIP = ip; }
-    public static void setJetsonIP(String ip) { jetsonIP = ip; }
+    // Note: updateAddresses() pulls IP's from this main controller
+    public static void setDriveIP(String ip) {
+        driveIP = ip;
+        cameras.updateAddresses();
+    }
+    public static void setScience1IP(String ip) {
+        science1IP = ip;
+        cameras.updateAddresses();
+    }
+    public static void setArmIP(String ip) {
+        armIP = ip;
+        cameras.updateAddresses();
+    }
+    public static void setJetsonIP(String ip) {
+        jetsonIP = ip;
+        cameras.updateAddresses();
+    }
 
     public static String getJestonIP() { return jetsonIP; }
 }

--- a/src/sample/Controller.java
+++ b/src/sample/Controller.java
@@ -58,7 +58,7 @@ public class Controller implements Initializable {
         public void handle(ActionEvent event) {
             try {
                 cameras.update();
-                System.out.println("UPDATE");
+               
             } catch (Exception e) {
                 /* Do nothing */
             }


### PR DESCRIPTION
- fetches this test rover image every 0.4 seconds
- GUI starts to lag a lot (at least on my machine and school wifi) if time is set under 0.2 seconds
- there's some code that's commented out that will need to be uncommented once the Jetson camera stuff is implemented (ie. setting fetch IP's to not this test image)
- I'll create another issue to remind us of that ^

![test_rover](https://user-images.githubusercontent.com/32744533/48782052-4a9a7780-ecab-11e8-824c-3d67909f1898.png)
